### PR TITLE
feat: upgrade package to support Laravel 10, 11 & 12

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,19 +12,26 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        php: [8.1]
-        laravel: [9.*]
-        stability: [prefer-lowest, prefer-stable]
+        os: [ubuntu-latest]
+        php: [8.2, 8.3, 8.4]
+        laravel: [10.*, 11.*, 12.*]
+        stability: [prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
+          - laravel: 10.*
+            testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
+        exclude:
+          - php: 8.4
+            laravel: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -16,23 +16,22 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/contracts": "^9.0|^10.0",
-        "illuminate/support": "^9.0|^10.0",
-        "robinvdvleuten/ulid": "^5.0",
-        "spatie/laravel-package-tools": "^1.9.2"
+        "php": "^8.2",
+        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0",
+        "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^6.0|^7.0",
-        "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^7.0",
-        "pestphp/pest": "^1.21",
-        "pestphp/pest-plugin-laravel": "^1.1",
+        "larastan/larastan": "^2.0|^3.0",
+        "nunomaduro/collision": "^7.0|^8.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "pestphp/pest": "^2.0|^3.0",
+        "pestphp/pest-plugin-laravel": "^2.0|^3.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5|^10.0"
+        "phpunit/phpunit": "^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,11 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Access to an undefined property class@anonymous/SupportServiceProvider\\.php\\:114\\:\\:\\$merge\\.$#"
+			count: 2
+			path: src/SupportServiceProvider.php
+
+		-
+			message: "#^Method class@anonymous/SupportServiceProvider\\.php\\:114\\:\\:links\\(\\) should return Illuminate\\\\Contracts\\\\Support\\\\Htmlable but returns Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\), array\\<string, mixed\\>\\>\\.$#"
+			count: 1
+			path: src/SupportServiceProvider.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,10 +5,7 @@ parameters:
     level: 4
     paths:
         - src
-        - config
-        - database
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
     bootstrap="vendor/autoload.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
     executionOrder="random"
@@ -16,24 +12,15 @@
     failOnRisky="true"
     failOnEmptyTestSuite="true"
     beStrictAboutOutputDuringTests="true"
-    verbose="true"
 >
     <testsuites>
         <testsuite name="Kedeka Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
+    </source>
 </phpunit>

--- a/src/Database/Concerns/HasUlid.php
+++ b/src/Database/Concerns/HasUlid.php
@@ -3,7 +3,7 @@
 namespace Kedeka\Support\Database\Concerns;
 
 use Illuminate\Support\Facades\Schema;
-use Ulid\Ulid;
+use Illuminate\Support\Str;
 
 trait HasUlid
 {
@@ -12,7 +12,7 @@ trait HasUlid
         static::creating(function ($model) {
             if (Schema::hasColumn($model->getTable(), 'ulid')) {
                 if (! $model->ulid) {
-                    $model->ulid = (string) Ulid::generate();
+                    $model->ulid = (string) Str::ulid();
                 }
             }
         });

--- a/src/Database/Concerns/UlidAsPrimary.php
+++ b/src/Database/Concerns/UlidAsPrimary.php
@@ -2,7 +2,7 @@
 
 namespace Kedeka\Support\Database\Concerns;
 
-use Ulid\Ulid;
+use Illuminate\Support\Str;
 
 trait UlidAsPrimary
 {
@@ -10,7 +10,7 @@ trait UlidAsPrimary
     {
         static::creating(function ($model) {
             if (! $model->id) {
-                $model->id = (string) Ulid::generate();
+                $model->id = (string) Str::ulid();
             }
         });
     }

--- a/src/Support.php
+++ b/src/Support.php
@@ -2,6 +2,4 @@
 
 namespace Kedeka\Support;
 
-class Support
-{
-}
+class Support {}

--- a/src/SupportServiceProvider.php
+++ b/src/SupportServiceProvider.php
@@ -83,6 +83,15 @@ class SupportServiceProvider extends PackageServiceProvider
             }
 
             $manifestPath = public_path('build/manifest.json');
+
+            if (! file_exists($manifestPath)) {
+                $manifestPath = public_path('build/.vite/manifest.json');
+            }
+
+            if (! file_exists($manifestPath)) {
+                throw new Exception('Vite manifest not found');
+            }
+
             $manifests = json_decode(file_get_contents($manifestPath), true);
 
             $css = $manifests['resources/js/app.js']['css'][0] ?? null;

--- a/src/SupportServiceProvider.php
+++ b/src/SupportServiceProvider.php
@@ -4,6 +4,7 @@ namespace Kedeka\Support;
 
 use Exception;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Vite;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\UrlWindow;
@@ -79,7 +80,7 @@ class SupportServiceProvider extends PackageServiceProvider
     {
         Blade::directive('viteCssOnly', function ($expression) {
             if (is_file(public_path('/hot'))) {
-                return app(\Illuminate\Foundation\Vite::class)('resources/css/app.css');
+                return app(Vite::class)('resources/css/app.css');
             }
 
             $manifestPath = public_path('build/manifest.json');

--- a/tests/Fixtures/SluggableModel.php
+++ b/tests/Fixtures/SluggableModel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Kedeka\Support\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Kedeka\Support\Database\Concerns\HasSlug;
+
+class SluggableModel extends Model
+{
+    use HasSlug;
+
+    protected $guarded = [];
+}

--- a/tests/Fixtures/SluggableWithCustomColumnModel.php
+++ b/tests/Fixtures/SluggableWithCustomColumnModel.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Kedeka\Support\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Kedeka\Support\Database\Concerns\HasSlug;
+
+class SluggableWithCustomColumnModel extends Model
+{
+    use HasSlug;
+
+    protected $table = 'sluggable_models';
+
+    protected $guarded = [];
+
+    protected string $slugColumn = 'name';
+}

--- a/tests/Fixtures/UlidModel.php
+++ b/tests/Fixtures/UlidModel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Kedeka\Support\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Kedeka\Support\Database\Concerns\HasUlid;
+
+class UlidModel extends Model
+{
+    use HasUlid;
+
+    protected $guarded = [];
+}

--- a/tests/Fixtures/UlidPrimaryModel.php
+++ b/tests/Fixtures/UlidPrimaryModel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Kedeka\Support\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Kedeka\Support\Database\Concerns\UlidAsPrimary;
+
+class UlidPrimaryModel extends Model
+{
+    use UlidAsPrimary;
+
+    protected $guarded = [];
+}

--- a/tests/HasSlugTest.php
+++ b/tests/HasSlugTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Kedeka\Support\Tests\Fixtures\SluggableModel;
+use Kedeka\Support\Tests\Fixtures\SluggableWithCustomColumnModel;
+
+describe('HasSlug', function () {
+    it('generates slug from title on saving', function () {
+        $model = SluggableModel::create(['title' => 'Hello World']);
+
+        expect($model->slug)->toBe('hello-world');
+    });
+
+    it('generates slug from name when title is null', function () {
+        $model = SluggableModel::create(['name' => 'My Name']);
+
+        expect($model->slug)->toBe('my-name');
+    });
+
+    it('does not overwrite existing slug', function () {
+        $model = SluggableModel::create([
+            'title' => 'Hello World',
+            'slug' => 'custom-slug',
+        ]);
+
+        expect($model->slug)->toBe('custom-slug');
+    });
+
+    it('uses custom sluggable column when defined', function () {
+        $model = SluggableWithCustomColumnModel::create(['name' => 'Custom Column']);
+
+        expect($model->slug)->toBe('custom-column');
+    });
+
+    it('handles special characters in slug', function () {
+        $model = SluggableModel::create(['title' => 'Hello & World! @#$']);
+
+        expect($model->slug)->toBe('hello-world-at');
+    });
+});

--- a/tests/HasUlidTest.php
+++ b/tests/HasUlidTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Kedeka\Support\Tests\Fixtures\UlidModel;
+
+describe('HasUlid', function () {
+    it('generates ulid on creating', function () {
+        $model = UlidModel::create(['name' => 'Test']);
+
+        expect($model->ulid)
+            ->toBeString()
+            ->toHaveLength(26);
+    });
+
+    it('does not overwrite existing ulid', function () {
+        $model = UlidModel::create([
+            'name' => 'Test',
+            'ulid' => '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        ]);
+
+        expect($model->ulid)->toBe('01ARZ3NDEKTSV4RRFFQ69G5FAV');
+    });
+
+    it('generates unique ulids for different models', function () {
+        $model1 = UlidModel::create(['name' => 'Test 1']);
+        $model2 = UlidModel::create(['name' => 'Test 2']);
+
+        expect($model1->ulid)->not->toBe($model2->ulid);
+    });
+
+    it('persists ulid to database', function () {
+        $model = UlidModel::create(['name' => 'Test']);
+
+        $found = UlidModel::where('ulid', $model->ulid)->first();
+
+        expect($found)->not->toBeNull()
+            ->and($found->name)->toBe('Test');
+    });
+});

--- a/tests/RememberQueryStringsTest.php
+++ b/tests/RememberQueryStringsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Session;
+use Kedeka\Support\Middleware\RememberQueryStrings;
+
+describe('RememberQueryStrings', function () {
+    beforeEach(function () {
+        $this->middleware = new RememberQueryStrings;
+    });
+
+    it('passes through json requests without remembering', function () {
+        $request = Request::create('/test', 'GET', ['page' => '2']);
+        $request->headers->set('Accept', 'application/json');
+        $route = new Route('GET', '/test', fn () => 'ok');
+        $route->name('test.index');
+        $request->setRouteResolver(fn () => $route);
+
+        $response = $this->middleware->handle($request, fn () => new Response('ok'));
+
+        expect($response->getContent())->toBe('ok');
+    });
+
+    it('passes through when remember is set to no', function () {
+        $request = Request::create('/test', 'GET', ['page' => '2', 'remember' => 'no']);
+
+        $route = new Route('GET', '/test', fn () => 'ok');
+        $route->name('test.index');
+        $request->setRouteResolver(fn () => $route);
+        $request->setLaravelSession(app('session.store'));
+
+        $response = $this->middleware->handle($request, fn () => new Response('ok'));
+
+        expect($response->getContent())->toBe('ok');
+    });
+
+    it('stores query strings in session', function () {
+        $request = Request::create('/test', 'GET', ['page' => '2', 'search' => 'hello']);
+
+        $route = new Route('GET', '/test', fn () => 'ok');
+        $route->name('test.index');
+        $request->setRouteResolver(fn () => $route);
+        $request->setLaravelSession(app('session.store'));
+
+        $this->middleware->handle($request, fn () => new Response('ok'));
+
+        $stored = session('remember_query_strings.test.index');
+        expect($stored)->toBe(['page' => '2', 'search' => 'hello']);
+    });
+
+    it('redirects to remembered query strings when no params', function () {
+        session(['remember_query_strings.test.index' => ['page' => '3', 'search' => 'foo']]);
+
+        $request = Request::create('/test', 'GET');
+
+        $route = new Route('GET', '/test', fn () => 'ok');
+        $route->name('test.index');
+        $request->setRouteResolver(fn () => $route);
+        $request->setLaravelSession(app('session.store'));
+
+        $response = $this->middleware->handle($request, fn () => new Response('ok'));
+
+        expect($response->getStatusCode())->toBe(302)
+            ->and($response->headers->get('Location'))->toContain('page=3')
+            ->and($response->headers->get('Location'))->toContain('search=foo');
+    });
+
+    it('forgets remembered query strings when remember is forget', function () {
+        session(['remember_query_strings.test.index' => ['page' => '3']]);
+
+        $request = Request::create('/test', 'GET', ['remember' => 'forget']);
+
+        $route = new Route('GET', '/test', fn () => 'ok');
+        $route->name('test.index');
+        $request->setRouteResolver(fn () => $route);
+        $request->setLaravelSession(app('session.store'));
+
+        $response = $this->middleware->handle($request, fn () => new Response('ok'));
+
+        expect($response->getStatusCode())->toBe(302)
+            ->and(session('remember_query_strings.test.index'))->toBeNull();
+    });
+});

--- a/tests/RememberQueryStringsTest.php
+++ b/tests/RememberQueryStringsTest.php
@@ -3,7 +3,6 @@
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Route;
-use Illuminate\Support\Facades\Session;
 use Kedeka\Support\Middleware\RememberQueryStrings;
 
 describe('RememberQueryStrings', function () {

--- a/tests/SupportServiceProviderTest.php
+++ b/tests/SupportServiceProviderTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+
+describe('SupportServiceProvider', function () {
+    it('registers ulidAlias blueprint macro', function () {
+        expect(Blueprint::hasMacro('ulidAlias'))->toBeTrue();
+    });
+
+    it('registers ulidPrimary blueprint macro', function () {
+        expect(Blueprint::hasMacro('ulidPrimary'))->toBeTrue();
+    });
+
+    it('registers viteCssOnly blade directive', function () {
+        $directives = app('blade.compiler')->getCustomDirectives();
+
+        expect($directives)->toHaveKey('viteCssOnly');
+    });
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,8 @@
 namespace Kedeka\Support\Tests;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 use Kedeka\Support\SupportServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
@@ -15,6 +17,8 @@ class TestCase extends Orchestra
         Factory::guessFactoryNamesUsing(
             fn (string $modelName) => 'Kedeka\\Support\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
+
+        $this->setUpDatabase();
     }
 
     protected function getPackageProviders($app)
@@ -27,10 +31,29 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');
+    }
 
-        /*
-        $migration = include __DIR__.'/../database/migrations/create_support_table.php.stub';
-        $migration->up();
-        */
+    protected function setUpDatabase(): void
+    {
+        Schema::create('sluggable_models', function (Blueprint $table) {
+            $table->id();
+            $table->string('title')->nullable();
+            $table->string('name')->nullable();
+            $table->string('slug')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('ulid_models', function (Blueprint $table) {
+            $table->id();
+            $table->string('ulid', 26)->unique()->nullable();
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('ulid_primary_models', function (Blueprint $table) {
+            $table->string('id', 26)->primary();
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
     }
 }

--- a/tests/UlidAsPrimaryTest.php
+++ b/tests/UlidAsPrimaryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Kedeka\Support\Tests\Fixtures\UlidPrimaryModel;
+
+describe('UlidAsPrimary', function () {
+    it('generates ulid as primary key on creating', function () {
+        $model = UlidPrimaryModel::create(['name' => 'Test']);
+
+        expect($model->id)
+            ->toBeString()
+            ->toHaveLength(26);
+    });
+
+    it('does not overwrite existing id', function () {
+        $model = UlidPrimaryModel::create([
+            'id' => '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+            'name' => 'Test',
+        ]);
+
+        expect($model->id)->toBe('01ARZ3NDEKTSV4RRFFQ69G5FAV');
+    });
+
+    it('uses string as key type', function () {
+        $model = new UlidPrimaryModel;
+
+        expect($model->getKeyType())->toBe('string');
+    });
+
+    it('disables auto incrementing', function () {
+        $model = new UlidPrimaryModel;
+
+        expect($model->getIncrementing())->toBeFalse();
+    });
+
+    it('uses id as key name', function () {
+        $model = new UlidPrimaryModel;
+
+        expect($model->getKeyName())->toBe('id');
+    });
+
+    it('can find model by ulid primary key', function () {
+        $model = UlidPrimaryModel::create(['name' => 'Findable']);
+
+        $found = UlidPrimaryModel::find($model->id);
+
+        expect($found)->not->toBeNull()
+            ->and($found->name)->toBe('Findable');
+    });
+
+    it('generates unique ids for different models', function () {
+        $model1 = UlidPrimaryModel::create(['name' => 'Test 1']);
+        $model2 = UlidPrimaryModel::create(['name' => 'Test 2']);
+
+        expect($model1->id)->not->toBe($model2->id);
+    });
+});


### PR DESCRIPTION
## Breaking Changes
- Drop Laravel 9 support
- Drop PHP 8.1 support (minimum PHP 8.2)
- Remove `robinvdvleuten/ulid` dependency (replaced with `Str::ulid()`)

## Changes
- Bump `illuminate/*` to `^10.0|^11.0|^12.0`
- Migrate ULID traits to use `Str::ulid()`
- Add Vite 5 manifest fallback to `@viteCssOnly` directive
- Modernize `phpunit.xml.dist` for PHPUnit 10+/11
- Update CI matrix: PHP 8.2-8.4, Laravel 10-12
- Rename `nunomaduro/larastan` to `larastan/larastan`
- Bump Pest to `^2.0|^3.0`, PHPUnit to `^10.0|^11.0`
- Cleanup PHPStan config and regenerate baseline

## Tests
- 25 tests, 32 assertions — all passing
- Added comprehensive tests for HasSlug, HasUlid, UlidAsPrimary, RememberQueryStrings, SupportServiceProvider